### PR TITLE
Fixed a crash that happened when locking the screen.

### DIFF
--- a/sound-output-device-chooser@kgshank.net/convenience.js
+++ b/sound-output-device-chooser@kgshank.net/convenience.js
@@ -216,11 +216,13 @@ function getProfilesForPort(portName, card) {
         for (let port of card.ports) {
             if(portName === port.name) {
                 let profiles = [];
-                for (let profile of port.profiles) {
-                    if(profile.indexOf('+input:') == -1) {
-                        for (let cardProfile of card.profiles) {
-                            if(profile === cardProfile.name) {
-                                profiles.push(cardProfile);
+                if (port.profiles) {
+                    for (let profile of port.profiles) {
+                        if(profile.indexOf('+input:') == -1) {
+                            for (let cardProfile of card.profiles) {
+                                if(profile === cardProfile.name) {
+                                    profiles.push(cardProfile);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This extension crashed for me on Ubuntu 18.04 whenever I locked the screen and sometimes randomly. I found out this was due to "port.profiles is undefined" error, described in #26 and #27.

My fix is very naive, it may not be a perfect solution. It works for me so far and it should not break anything more than it is right now.