### PR TITLE
Settings: Fill available space with port settings

### DIFF
--- a/sound-output-device-chooser@kgshank.net/ui/prefs-dialog.gtkbuilder
+++ b/sound-output-device-chooser@kgshank.net/ui/prefs-dialog.gtkbuilder
@@ -538,116 +538,99 @@
                 <property name="label_xalign">0</property>
                 <property name="shadow_type">out</property>
                 <child>
-                  <object class="GtkAlignment">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="vexpand">True</property>
+                    <property name="margin_left">4</property>
+                    <property name="margin_right">4</property>
+                    <property name="margin_top">0</property>
+                    <property name="margin_bottom">4</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkListBox">
+                      <object class="GtkScrolledWindow" id="scrolledwindow1">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can_focus">True</property>
+                        <property name="opacity">0.99999999865889544</property>
+                        <property name="hexpand">True</property>
                         <property name="vexpand">True</property>
+                        <property name="resize_mode">queue</property>
+                        <property name="shadow_type">in</property>
                         <child>
-                          <object class="GtkListBoxRow">
+                          <object class="GtkTreeView" id="port-treeview">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="vexpand">True</property>
+                            <property name="model">ports-store</property>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection" id="treeview-selection1"/>
+                            </child>
                             <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="vexpand">True</property>
-                                <property name="orientation">vertical</property>
+                              <object class="GtkTreeViewColumn" id="PortNameColumn">
+                                <property name="resizable">True</property>
+                                <property name="sizing">autosize</property>
+                                <property name="min_width">100</property>
+                                <property name="title" translatable="yes">Name</property>
+                                <property name="expand">True</property>
+                                <property name="sort_order">descending</property>
                                 <child>
-                                  <object class="GtkScrolledWindow" id="scrolledwindow1">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="opacity">0.99999999865889544</property>
-                                    <property name="hexpand">True</property>
-                                    <property name="vexpand">True</property>
-                                    <property name="resize_mode">queue</property>
-                                    <property name="shadow_type">in</property>
-                                    <child>
-                                      <object class="GtkTreeView" id="port-treeview">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="vexpand">True</property>
-                                        <property name="model">ports-store</property>
-                                        <child internal-child="selection">
-                                          <object class="GtkTreeSelection" id="treeview-selection1"/>
-                                        </child>
-                                        <child>
-                                          <object class="GtkTreeViewColumn" id="PortNameColumn">
-                                            <property name="resizable">True</property>
-                                            <property name="sizing">autosize</property>
-                                            <property name="min_width">100</property>
-                                            <property name="title" translatable="yes">Name</property>
-                                            <property name="expand">True</property>
-                                            <property name="sort_order">descending</property>
-                                            <child>
-                                              <object class="GtkCellRendererText" id="PortNameRenderer"/>
-                                              <attributes>
-                                                <attribute name="text">0</attribute>
-                                              </attributes>
-                                            </child>
-                                          </object>
-                                        </child>
-                                        <child>
-                                          <object class="GtkTreeViewColumn" id="ShowAlwaysColumn">
-                                            <property name="sizing">autosize</property>
-                                            <property name="title" translatable="yes">Show</property>
-                                            <child>
-                                              <object class="GtkCellRendererToggle" id="ShowAlwaysToggleRender">
-                                                <property name="radio">True</property>
-                                              </object>
-                                              <attributes>
-                                                <attribute name="active">1</attribute>
-                                              </attributes>
-                                            </child>
-                                          </object>
-                                        </child>
-                                        <child>
-                                          <object class="GtkTreeViewColumn" id="HideAlwaysColumn">
-                                            <property name="sizing">autosize</property>
-                                            <property name="title" translatable="yes">Hide</property>
-                                            <child>
-                                              <object class="GtkCellRendererToggle" id="HideAlwaysToggleRender">
-                                                <property name="radio">True</property>
-                                              </object>
-                                              <attributes>
-                                                <attribute name="active">2</attribute>
-                                              </attributes>
-                                            </child>
-                                          </object>
-                                        </child>
-                                        <child>
-                                          <object class="GtkTreeViewColumn" id="ShowOnActiveColumn">
-                                            <property name="sizing">autosize</property>
-                                            <property name="title" translatable="yes">Default</property>
-                                            <child>
-                                              <object class="GtkCellRendererToggle" id="ShowActiveToggleRender">
-                                                <property name="radio">True</property>
-                                              </object>
-                                              <attributes>
-                                                <attribute name="active">3</attribute>
-                                              </attributes>
-                                            </child>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
+                                  <object class="GtkCellRendererText" id="PortNameRenderer"/>
+                                  <attributes>
+                                    <attribute name="text">0</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkTreeViewColumn" id="ShowAlwaysColumn">
+                                <property name="sizing">autosize</property>
+                                <property name="title" translatable="yes">Show</property>
+                                <child>
+                                  <object class="GtkCellRendererToggle" id="ShowAlwaysToggleRender">
+                                    <property name="radio">True</property>
                                   </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
+                                  <attributes>
+                                    <attribute name="active">1</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkTreeViewColumn" id="HideAlwaysColumn">
+                                <property name="sizing">autosize</property>
+                                <property name="title" translatable="yes">Hide</property>
+                                <child>
+                                  <object class="GtkCellRendererToggle" id="HideAlwaysToggleRender">
+                                    <property name="radio">True</property>
+                                  </object>
+                                  <attributes>
+                                    <attribute name="active">2</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkTreeViewColumn" id="ShowOnActiveColumn">
+                                <property name="sizing">autosize</property>
+                                <property name="title" translatable="yes">Default</property>
+                                <child>
+                                  <object class="GtkCellRendererToggle" id="ShowActiveToggleRender">
+                                    <property name="radio">True</property>
+                                  </object>
+                                  <attributes>
+                                    <attribute name="active">3</attribute>
+                                  </attributes>
                                 </child>
                               </object>
                             </child>
                           </object>
                         </child>
                       </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                 </child>


### PR DESCRIPTION
Replace GtkListBox with a simple GtkBox + margins so that all available
vertical space is made available to child GtkScrolledWindow.

Note: The diff looks like a lot changed, but really the only change is the replacement of four parents of `GtkScrolledWindow` with a single parent `GtkBox` that includes some margin to retain the same look.

Fixes #33 and #24 