### PR TITLE
Fix SignalManager declaration warning for export

### DIFF
--- a/sound-output-device-chooser@kgshank.net/convenience.js
+++ b/sound-output-device-chooser@kgshank.net/convenience.js
@@ -173,7 +173,7 @@ const Signal = new Lang.Class({
     }
 });
 
-const SignalManager = new Lang.Class({
+var SignalManager = new Lang.Class({
 	Name: 'SignalManager',
 
 	_init: function() {


### PR DESCRIPTION
Address the following warning:

gnome-shell-ext[9438]: Some code accessed the property SignalManager'
on the module 'convenience'. That property was defined with 'let' or
'const' inside the module. This was previously supported, but is not
correct according to the ES6 standard. Any symbols to be exported from
a module must be defined with 'var'. The property access will work as
previously for the time being, but please fix your code anyway.