### PR TITLE
auto hide device-chooser when there are no devices

### DIFF
--- a/sound-output-device-chooser@kgshank.net/base.js
+++ b/sound-output-device-chooser@kgshank.net/base.js
@@ -198,6 +198,7 @@ const SoundDeviceChooserBase = new Lang.Class({
             this._deviceRemoved(control, id, true);
         }
         this._setChooserVisibility();
+        this._setVisibility();
         return uidevice;
     },
 
@@ -245,6 +246,7 @@ const SoundDeviceChooserBase = new Lang.Class({
                 return false;
             }));
             this._setChooserVisibility();
+            this._setVisibility();
         }
     },
 
@@ -403,7 +405,11 @@ const SoundDeviceChooserBase = new Lang.Class({
     },
 
     _setVisibility : function() {
-        this.actor.visible =  this._settings.get_boolean(this._show_device_signal);
+        if (!this._settings.get_boolean(this._show_device_signal))
+            this.actor.visible = false;
+        else
+            // if setting says to show device, check for any device, otherwise hide the "actor"
+            this.actor.visible = (Object.keys(this._availableDevicesIds).length > 0);
     },
 
     destroy: function() {


### PR DESCRIPTION
Hey, I love this extension but 1 small issue bugged me. 
if you have no input devices connected (no mic), the extension will show 'Extension initializing..." forever (where the input-device chooser should be).
So I fixed it here by automatically hiding the device-chooser if there are currently 0 known devices.

Feel free to comment me if I did this fix in a bad way and you would do it differently.

from my commit msg: 
> updated _setVisibility to show the device chooser only when atleast 1 device found, otherwise it will be hidden.
> also updated _deviceAdded and _deviceRemoved to invoke '_setVisibility' hide/show when number of devices changes