### PR TITLE
Update compatible version

### DIFF
--- a/sound-output-device-chooser@kgshank.net/metadata.json
+++ b/sound-output-device-chooser@kgshank.net/metadata.json
@@ -12,7 +12,7 @@
     "3.26",
     "3.28",
     "3.30",
-    "3.31"
+    "3.32"
   ],
   "url": "https://github.com/kgshank/gse-sound-output-device-chooser",
   "uuid": "sound-output-device-chooser@kgshank.net",


### PR DESCRIPTION
Even if the last commit fixed compatibility with 3.32, I believe compatibility has to be stated in the metadata for it to be installable through the extensions store.