### PR TITLE
Detect streams with null port at initialization

### DIFF
--- a/sound-output-device-chooser@kgshank.net/base.js
+++ b/sound-output-device-chooser@kgshank.net/base.js
@@ -91,8 +91,11 @@ var SoundDeviceChooserBase = class SoundDeviceChooserBase extends PopupMenu.Popu
                         let stream = this._control.get_stream_from_device(uidevice);
                         if(stream) {
                             let stream_port = stream.get_port();
+                            let uidevice_port = uidevice.get_port();
 
-                            if(stream_port && stream == defaultDevice && stream_port.port === uidevice.get_port()) {
+                            if(((!stream_port && !uidevice_port) ||
+                                (stream_port && stream_port.port === uidevice_port)) &&
+                                stream == defaultDevice) {
                                 this._deviceActivated(this._control, id);
                             }
                         }


### PR DESCRIPTION
Fixes https://github.com/kgshank/gse-sound-output-device-chooser/issues/42

The pulseaudio equalizer sink has a null port so it's not initialized as the current sink at starup. This commit introduces a conservative fix: allow null ports only if both the stream port and the uidevice port is null.