### PR TITLE
Update metadata.json to include Gnome 3.38

### DIFF
--- a/sound-output-device-chooser@kgshank.net/metadata.json
+++ b/sound-output-device-chooser@kgshank.net/metadata.json
@@ -6,7 +6,8 @@
   "shell-version": [
     "3.34",
     "3.32",
-    "3.36"
+    "3.36",
+    "3.38"
   ],
   "url": "https://github.com/kgshank/gse-sound-output-device-chooser",
   "uuid": "sound-output-device-chooser@kgshank.net",


### PR DESCRIPTION
Fixes #116 