### PR TITLE
Delete reference to removed object

### DIFF
--- a/sound-output-device-chooser@kgshank.net/base.js
+++ b/sound-output-device-chooser@kgshank.net/base.js
@@ -245,6 +245,7 @@ var SoundDeviceChooserBase = class SoundDeviceChooserBase{
 
     _deviceRemoved(control, id, dontcheck) {
         let obj = this._devices[id];
+        delete this._devices[id];
         if(obj && obj.active) {
             _d("Removed: " + id);
             if(!dontcheck && this._canShowDevice(obj.uidevice, false)) {


### PR DESCRIPTION
This prevents calling a C function with an old pointer from the JS
timeout callback which then crashes the GNOME Shell.
An upstream fix was also sent in which prevents the crash of GNOME
Shell but still this bug here needs to be fixed.

Fixes #110 #108