### PR TITLE
🐛 fixes `undefined` in name in port-settings

### DIFF
--- a/sound-output-device-chooser@kgshank.net/convenience.js
+++ b/sound-output-device-chooser@kgshank.net/convenience.js
@@ -79,6 +79,12 @@ function getCard(card_index) {
     return cards[card_index];
 }
 
+function getCardByName(card_name) {
+    if (!cards || Object.keys(cards).length == 0) {
+        refreshCards();
+    }
+    return Object.keys(cards).map((index) => cards[index]).find(({name}) => name === card_name)
+}
 
 function getProfiles(control, uidevice) {
     let stream = control.lookup_stream_id(uidevice.get_stream_id());

--- a/sound-output-device-chooser@kgshank.net/prefs.js
+++ b/sound-output-device-chooser@kgshank.net/prefs.js
@@ -73,7 +73,9 @@ function setPortsSettings(ports,_settings) {
 }
 
 function getPortDisplayName(port) {
-        return port.card_description + " - " + port.human_name;
+    const card = Lib.getCardByName(port.card_name);
+    const description = card && card.card_description
+    return `${port.human_name} - ${description}`;
 }
 
 function migratePortSettings(currVersion, currSettings, _settings) {


### PR DESCRIPTION
For each port, retrieves the corresponding card and uses `card_description` to build port display name.

Port name should now be the same as in gnome sound settings