### PR TITLE
Fix bug when disabling extension while slider integration is enabled

### DIFF
--- a/sound-output-device-chooser@kgshank.net/extension.js
+++ b/sound-output-device-chooser@kgshank.net/extension.js
@@ -162,7 +162,7 @@ var SDCInstance = class SDCInstance {
             this._volumeMenuInstance = new VolumeMenuInstance(this._volumeMenu, this._settings);
         }
 
-        this._canIntegradeMenu = true;
+        this._allowIntegrateMenu = true;
         this._addMenuItem(this._volumeMenu, this._volumeMenu._output.item, this._outputInstance.menuItem);
         this._addMenuItem(this._volumeMenu, this._volumeMenu._input.item, this._inputInstance.menuItem);
         this._expandVolMenu();
@@ -185,7 +185,7 @@ var SDCInstance = class SDCInstance {
     }
 
     _canIntegrateMenuItem(menuItem) {
-        return this._canIntegradeMenu && menuItem.visible && this._settings.get_boolean(Prefs.INTEGRATE_WITH_SLIDER);
+        return this._allowIntegrateMenu && menuItem.visible && this._settings.get_boolean(Prefs.INTEGRATE_WITH_SLIDER);
     }
 
     _expandVolMenu() {
@@ -246,7 +246,7 @@ var SDCInstance = class SDCInstance {
         this._settings = null;
         this._signalManager.disconnectAll();
         this._signalManager = null;
-        this._canIntegradeMenu = false;
+        this._allowIntegrateMenu = false;
         this._switchSubmenuMenu();
         this._revertVolMenuChanges();
         if (this._outputInstance) {

--- a/sound-output-device-chooser@kgshank.net/extension.js
+++ b/sound-output-device-chooser@kgshank.net/extension.js
@@ -162,6 +162,7 @@ var SDCInstance = class SDCInstance {
             this._volumeMenuInstance = new VolumeMenuInstance(this._volumeMenu, this._settings);
         }
 
+        this._canIntegradeMenu = true;
         this._addMenuItem(this._volumeMenu, this._volumeMenu._output.item, this._outputInstance.menuItem);
         this._addMenuItem(this._volumeMenu, this._volumeMenu._input.item, this._inputInstance.menuItem);
         this._expandVolMenu();
@@ -184,7 +185,7 @@ var SDCInstance = class SDCInstance {
     }
 
     _canIntegrateMenuItem(menuItem) {
-        return menuItem.visible && this._settings.get_boolean(Prefs.INTEGRATE_WITH_SLIDER);
+        return this._canIntegradeMenu && menuItem.visible && this._settings.get_boolean(Prefs.INTEGRATE_WITH_SLIDER);
     }
 
     _expandVolMenu() {
@@ -245,6 +246,8 @@ var SDCInstance = class SDCInstance {
         this._settings = null;
         this._signalManager.disconnectAll();
         this._signalManager = null;
+        this._canIntegradeMenu = false;
+        this._switchSubmenuMenu();
         this._revertVolMenuChanges();
         if (this._outputInstance) {
             this._outputInstance.destroy();


### PR DESCRIPTION
More less the title...
If you disable the extension while the slider integration is enabled gnome-shell "losses" its volume slider.
This small 3 lines patch fix that.

Thank you and have a nice day :)