### PR TITLE
getActor() globally for 3.32 compatibility

### DIFF
--- a/sound-output-device-chooser@kgshank.net/base.js
+++ b/sound-output-device-chooser@kgshank.net/base.js
@@ -38,6 +38,7 @@ const Domain = Gettext.domain(Me.metadata["gettext-domain"]);
 const _ = Domain.gettext;
 //const _ = Gettext.gettext;
 const _d = Lib._log;
+const getActor = Lib.getActor;
 
 const DISPLAY_OPTIONS = Prefs.DISPLAY_OPTIONS;
 const SignalManager = Lib.SignalManager;
@@ -68,7 +69,7 @@ var ProfileMenuItem = class ProfileMenuItem
                 this.remove_style_pseudo_class('insensitive');
             }
             else {
-                this.actor.remove_style_pseudo_class('insensitive');
+                getActor(this).remove_style_pseudo_class('insensitive');
             }
         }
         else {
@@ -77,13 +78,13 @@ var ProfileMenuItem = class ProfileMenuItem
                 this.add_style_pseudo_class('insensitive');
             }
             else {
-                this.actor.add_style_pseudo_class('insensitive');
+                getActor(this).add_style_pseudo_class('insensitive');
             }
         }
     }
 
     setVisibility(visibility) {
-        this.actor.visible = visibility;
+        getActor(this).visible = visibility;
     }
 }
 
@@ -124,8 +125,8 @@ var SoundDeviceMenuItem = class SoundDeviceMenuItem extends PopupMenu.PopupImage
         this.available = true;
         this.activeProfile = "";
         this.activeDevice = false;
-        this.visible = false;
         this._displayOption = DISPLAY_OPTIONS.INITIAL;
+        getActor(this).visible = false;
     }
 
     isAvailable() {
@@ -149,11 +150,10 @@ var SoundDeviceMenuItem = class SoundDeviceMenuItem extends PopupMenu.PopupImage
     }
 
     setVisibility(_v) {
-        this.actor.visible = _v;
+        getActor(this).visible = _v;
         if (!_v) {
             this.profilesitems.forEach((p) => p.setVisibility(false));
         }
-        this.visible = _v;
     };
 
     setTitle(_t) {
@@ -163,7 +163,7 @@ var SoundDeviceMenuItem = class SoundDeviceMenuItem extends PopupMenu.PopupImage
     }
 
     isVisible() {
-        return this.visible;
+        return getActor(this).visible;
     }
 
     setActiveDevice(_a) {
@@ -235,7 +235,7 @@ var SoundDeviceChooserBase = class SoundDeviceChooserBase {
         }
 
         this._signalManager.addSignal(this.menuItem.menu, "open-state-changed", this._onSubmenuOpenStateChanged.bind(this));
-        this._signalManager.addSignal(this.menuItem, "notify::visible", () => {this.emit('update-visibility', this.menuItem.actor.visible);});
+        this._signalManager.addSignal(this.menuItem, "notify::visible", () => {this.emit('update-visibility', getActor(this.menuItem).visible);});
     }
 
     _getMixerControl() { return VolumeMenu.getMixerControl(); }
@@ -543,8 +543,8 @@ var SoundDeviceChooserBase = class SoundDeviceChooserBase {
         let visibility = this._getDeviceVisibility();
         this._getAvailableDevices().forEach(x => x.setVisibility(visibility))
 
-        //this.menuItem._triangleBin.visible = visibility;
-        //this.menuItem.actor.visible = visibility;
+        //getActor(this.menuItem._triangleBin).visible = visibility;
+        //getActor(this.menuItem).visible = visibility;
         this._setProfileVisibility();
         this.setVisible(visibility);
     }
@@ -559,7 +559,7 @@ var SoundDeviceChooserBase = class SoundDeviceChooserBase {
     }
     
     setVisible(visibility) {
-        this.menuItem.actor.visible = visibility;
+        getActor(this.menuItem).visible = visibility;
         //this.emit('update-visibility', visibility);    
     }
 

--- a/sound-output-device-chooser@kgshank.net/convenience.js
+++ b/sound-output-device-chooser@kgshank.net/convenience.js
@@ -350,3 +350,8 @@ function dump(obj) {
         catch (e) { _log(propName + "!!!Error!!!"); }
     }
 }
+
+function getActor(item) {
+    //.actor is needed for backward compatablity
+    return (item.actor) ? item.actor : item;
+}

--- a/sound-output-device-chooser@kgshank.net/extension.js
+++ b/sound-output-device-chooser@kgshank.net/extension.js
@@ -23,6 +23,7 @@ const Base = Me.imports.base;
 const Lib = Me.imports.convenience;
 const _d = Lib._log;
 const _dump = Lib.dump;
+const getActor = Lib.getActor;
 const SignalManager = Lib.SignalManager;
 const Prefs = Me.imports.prefs;
 const Main = imports.ui.main;
@@ -91,13 +92,13 @@ var VolumeMenuInstance = class VolumeMenuInstance {
 
         this._input._updateVisibilityOriginal = this._input._updateVisibility;
         this._input._updateVisibilityCustom = function() {
-            let old_state_visible = this.item.visible;
+            let old_state_visible = getActor(this.item).visible;
             let visible = this._shouldBeVisible();
 
             if (old_state_visible != visible) {
-                this.item.visible = visible;
+                getActor(this.item).visible = visible;
             } else {
-                this.item.notify('visible');
+                getActor(this.item).notify('visible');
             }
         };
         this._input._updateVisibility = this._input._updateVisibilityCustom;
@@ -173,9 +174,9 @@ var SDCInstance = class SDCInstance {
         this._signalManager.addSignal(this._inputInstance, "update-visibility", this._updateMenuVisibility.bind(this));
 
         //If slider disappears remove menu integration, getting complicated!!
-        this._signalManager.addSignal(this._getActor(this._volumeMenu._output.item),
+        this._signalManager.addSignal(getActor(this._volumeMenu._output.item),
             "notify::visible", () => { this._updateMenuVisibility(this._outputInstance, false) });
-        this._signalManager.addSignal(this._getActor(this._volumeMenu._input.item),
+        this._signalManager.addSignal(getActor(this._volumeMenu._input.item),
             "notify::visible", () => { this._updateMenuVisibility(this._inputInstance, false) });
     }
 
@@ -191,35 +192,30 @@ var SDCInstance = class SDCInstance {
 
     _expandVolMenu() {
         if (this._settings.get_boolean(Prefs.EXPAND_VOL_MENU)) {
-            this._aggregateLayout.addSizeChild(this._getActor(this._volumeMenu));
+            this._aggregateLayout.addSizeChild(getActor(this._volumeMenu));
         } else {
             this._revertVolMenuChanges();
         }
     }
 
     _revertVolMenuChanges() {
-        this._aggregateLayout._sizeChildren = this._aggregateLayout._sizeChildren.filter(item => item !== this._volumeMenu.actor);
+        this._aggregateLayout._sizeChildren = this._aggregateLayout._sizeChildren.filter(item => item !== getActor(this._volumeMenu));
         this._aggregateLayout.layout_changed();
-    }
-
-    _getActor(menuItem) {
-        //.actor is needed for backward compatablity
-        return (menuItem.actor) ? menuItem.actor : menuItem;
     }
 
     _updateMenuVisibility(menuInstance, visible) {
         if (menuInstance instanceof SoundOutputDeviceChooser) {
-            this._integrateMenu(this._volumeMenu, this._getActor(this._volumeMenu._output.item), this._getActor(menuInstance.menuItem), visible);
+            this._integrateMenu(this._volumeMenu, getActor(this._volumeMenu._output.item), getActor(menuInstance.menuItem), visible);
         } else {
-            this._integrateMenu(this._volumeMenu, this._getActor(this._volumeMenu._input.item), this._getActor(menuInstance.menuItem), visible);
+            this._integrateMenu(this._volumeMenu, getActor(this._volumeMenu._input.item), getActor(menuInstance.menuItem), visible);
         }
     }
 
     _switchSubmenuMenu() {
         _d("Output Device visibility");
-        this._updateMenuVisibility(this._outputInstance, this._getActor(this._outputInstance.menuItem).visible);
+        this._updateMenuVisibility(this._outputInstance, getActor(this._outputInstance.menuItem).visible);
         _d("Input Device visibility");
-        this._updateMenuVisibility(this._inputInstance, this._getActor(this._inputInstance.menuItem).visible);
+        this._updateMenuVisibility(this._inputInstance, getActor(this._inputInstance.menuItem).visible);
     }
 
     _integrateMenu(_volumeMenu, sliderItem, selectorItem, visible) {


### PR DESCRIPTION
From my understanding we want to be safe from an `actor` getter drop in a feature gnome-shell release.

This commit extent the idea of `getActor` in order to provide better support for gnome-shell 3.32 while also keeping safe from a drop of `actor` getter in a future gnome-shell release.

Should also fix #205 .