### PR TITLE
Fix installation rm instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To install the extension from source, clone the repository and place it in the `
 cd ~/.local/share/gnome-shell/extensions/
 
 # Remove older version
-rm -rf "*sound-output-device-chooser*"
+rm -rf *sound-output-device-chooser*
 
 # Clone current version
 git clone https://github.com/kgshank/gse-sound-output-device-chooser.git


### PR DESCRIPTION
The command as-is quotes the asterisk, so it attempts to remove a directory with literal asterisks in it.

```
$ echo rm -rf "*sound-output-device-chooser*"
rm -rf *sound-output-device-chooser*
$ echo rm -rf *sound-output-device-chooser*
rm -rf gse-sound-output-device-chooser sound-output-device-chooser@kgshank.net
```