### PR TITLE
Fix "Extension initialising..." when there are no devices

### DIFF
--- a/sound-output-device-chooser@kgshank.net/base.js
+++ b/sound-output-device-chooser@kgshank.net/base.js
@@ -531,11 +531,12 @@ var SoundDeviceChooserBase = class SoundDeviceChooserBase {
 
     _getDeviceVisibility() {
         let hideChooser = this._settings.get_boolean(Prefs.HIDE_ON_SINGLE_DEVICE);
+        let numAvailableDevices = this._getAvailableDevices().length;
         if (hideChooser) {
-            return (this._getAvailableDevices().length > 1);
+            return numAvailableDevices > 1;
         }
         else {
-            return true;
+            return numAvailableDevices > 0;
         }
     }
 


### PR DESCRIPTION
It looks like 2eee4716deeb6b995ec29cc5855879e17c6847f3 intended to fix this, but is not sufficient when "Hide selector if there's only one device" is off (the default).

See #195, #121

Before fix:
![Screenshot from 2022-01-25 23-29-07](https://user-images.githubusercontent.com/2019426/151124230-8da1db75-9b95-4e77-a146-e03b07a0fceb.png)

After fix:
![Screenshot from 2022-01-25 23-58-12](https://user-images.githubusercontent.com/2019426/151124568-57aa0c98-b69b-4818-bd26-8beaca5f5f62.png)