### PR TITLE
Add 42 since it works there too

### DIFF
--- a/sound-output-device-chooser@kgshank.net/metadata.json
+++ b/sound-output-device-chooser@kgshank.net/metadata.json
@@ -11,7 +11,8 @@
     "3.36",
     "3.38",
     "40",
-    "41"
+    "41",
+    "42"
   ],
   "url": "https://github.com/kgshank/gse-sound-output-device-chooser",
   "uuid": "sound-output-device-chooser@kgshank.net",


### PR DESCRIPTION
Tested on Ubuntu Jammy Jellyfish + GNOME PPA with gnome-shell 42~alpha.

Preferences works too.

Thanks for this nice and useful extension.