### PR TITLE
Properly fix for GNOME 42 / gjs 1.72.0 (#229).

### DIFF
--- a/sound-output-device-chooser@kgshank.net/base.js
+++ b/sound-output-device-chooser@kgshank.net/base.js
@@ -45,11 +45,6 @@ const SignalManager = Lib.SignalManager;
 
 var ProfileMenuItem = class ProfileMenuItem
     extends PopupMenu.PopupMenuItem {
-    constructor(title, profileName) {
-        super(title);
-        this._init(title, profileName);
-    }
-
     _init(title, profileName) {
         if (super._init) {
             super._init(title);
@@ -89,11 +84,6 @@ var ProfileMenuItem = class ProfileMenuItem
 }
 
 var SoundDeviceMenuItem = class SoundDeviceMenuItem extends PopupMenu.PopupImageMenuItem {
-    constructor(id, title, icon_name, profiles) {
-        super(title, icon_name);
-        this._init(id, title, icon_name, profiles);
-    }
-
     _init(id, title, icon_name, profiles) {
         if (super._init) {
             super._init(title, icon_name);


### PR DESCRIPTION
According to
https://gjs.guide/guides/gobject/subclassing.html#subclassing-gobject,
Javascript classes that subclass GObject must implement an _init()
initializer instead of using a regular constructor.  The ProfileMenuItem
and SoundDeviceMenuItem each subclass PopupMenu classes that ultimately
subclass a GObject class.

This has just worked because the constructor itself was called, and it
in turn was calling the correct _init methods.  gjs commit 16032db6cd2
(Correctly chain constructor prototypes to enable static inheritance)
made it so that constructors are called directly but the gjs
behavior of calling _init still occurs.  It occurs using this._init(),
though so what has happened is as follows.

SoundDeviceChooserBase._deviceAdded instantiates a SoundDeviceMenuItem
with four arguments that are passed to the constructor.  In turn,
the superclass's constructor is called with two of those arguments.  Due
to the change in gjs, the original class's _init routine is called from
the superclass's constructor but with only the two arguments passed to
it.  We end up with icon_name = null, which predictably blows up later.
The same issue affects ProfileMenuItem since the superclass's
constructor is only called with one argument instead of two.

The fix is simple: Follow the guidelines in the gjs guide for
subclassing GObject and just remove the constructors for both of those
classes in favor of just using _init().  The _init() methods already do
the right thing in calling the superclass's _init() method themselves.
AFAICT, this change should be compatible back to very old gjs versions
since that appears to be a long-standing guideline.