### PR TITLE
Style fix for Gnome 42 "Integrate selector with slider"

### DIFF
--- a/sound-output-device-chooser@kgshank.net/extension.js
+++ b/sound-output-device-chooser@kgshank.net/extension.js
@@ -233,7 +233,7 @@ var SDCInstance = class SDCInstance {
             selectorItem.label.hide();
             sliderItem.get_next_sibling().hide(); //expander
             selectorItem.icon.hide();
-            selectorItem.set_style('padding-top: 0px; padding-bottom: 0px');
+            selectorItem.set_style('padding-left: 0px;padding-top: 0px; padding-bottom: 0px');
         } else {
             _d("Not integrating with Volume menu")
             if (selectorItem.contains(sliderItem) == true) {


### PR DESCRIPTION
Tested it also on Gnome 3.36, doesn't brake old style.
Sad it that for few hour this fix might won't make it to next release.

// rant...
Personally I believe that we should push next releases with "Integrate selector with slider". Ofc, I am biased since I pushed for that integration. However I do believe that it look better and we should push it for new user by default (and ofc keeping the options to disable it). Should note that I daily drive it with enabled (if that proves some robustness). Maybe make a poll, idk. 