### PR TITLE
Show device name before the input name

### DIFF
--- a/sound-output-device-chooser@kgshank.net/base.js
+++ b/sound-output-device-chooser@kgshank.net/base.js
@@ -728,7 +728,7 @@ var SoundDeviceChooserBase = class SoundDeviceChooserBase {
     _getDeviceTitle(uidevice) {
         let title = uidevice.description;
         if (!this._settings.get_boolean(Prefs.OMIT_DEVICE_ORIGIN) && uidevice.origin != "")
-            title += " - " + uidevice.origin;
+            title = uidevice.origin + ": " + title ;
 
         return title;
     }


### PR DESCRIPTION
Device names are usually required when port names are not enough to distinguish audio ports. This commit puts the device name first, so it's much easier to visually find the desired port