### PR TITLE
Hide JamesDSP & EasyEffects Sinks/Sources from selectors.

### DIFF
--- a/sound-output-device-chooser@kgshank.net/base.js
+++ b/sound-output-device-chooser@kgshank.net/base.js
@@ -709,7 +709,7 @@ var SoundDeviceChooserBase = class SoundDeviceChooserBase {
     }
 
     _isDeviceInValid(uidevice) {
-        return (!uidevice || (uidevice.description != null && uidevice.description.match(/Dummy\s+(Output|Input)/gi)));
+        return (!uidevice || (uidevice.description != null && uidevice.description.match(/(Dummy|EasyEffects|JamesDSP)\s+(Output|Input|Sink|Source)/gi)));
     }
 
     _refreshDeviceTitles() {


### PR DESCRIPTION
Removes dummy inputs/outputs created by [JamesDSP](https://github.com/Audio4Linux/JDSP4Linux) and [EasyEffects](https://github.com/wwmm/easyeffects) that aren't meant to be selected.

Solves #216 