### PR TITLE
Add support for Gnome 43

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,4 +49,10 @@ $(LOCALE_DIR)/%/LC_MESSAGES/sound-output-device-chooser.mo: $(LOCALE_DIR)/%/LC_M
 install:
 	@echo "Installing extension files in $(INSTALL_DIR)/sound-output-device-chooser@kgshank.net"
 	mkdir -p $(INSTALL_DIR)
-	cp -r sound-output-device-chooser@kgshank.net  $(INSTALL_DIR)
+	cp -r $(SRC_DIR)  $(INSTALL_DIR)
+
+enable:
+	gnome-extensions enable $(SRC_DIR)
+
+disable:
+	gnome-extensions disable $(SRC_DIR)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ rm -rf "gse-sound-output-device-chooser"
 Enable the extensions from [GNOME Extensions App](https://gitlab.gnome.org/GNOME/gnome-shell/-/tree/main/subprojects/extensions-app).
 
 ### Gnome shell versions compatible
+* 43
 * 42
 * 41
 * 40

--- a/sound-output-device-chooser@kgshank.net/metadata.json
+++ b/sound-output-device-chooser@kgshank.net/metadata.json
@@ -12,7 +12,8 @@
     "3.38",
     "40",
     "41",
-    "42"
+    "42",
+    "43"
   ],
   "url": "https://github.com/kgshank/gse-sound-output-device-chooser",
   "uuid": "sound-output-device-chooser@kgshank.net",


### PR DESCRIPTION
Added Gnome "43" to the support "shell-version" in the metadata.json.

Also added two Makefile tasks to quickly enable/disable the plugin for local testing.

Tested this change quickly with Fedora 37 with Gnome 43.2 (and X11) and the plugin works still fine.