### PR TITLE
Implemented keyboard shortcuts for cycling input and output devices

### DIFF
--- a/sound-output-device-chooser@kgshank.net/extension.js
+++ b/sound-output-device-chooser@kgshank.net/extension.js
@@ -16,7 +16,7 @@
  ******************************************************************************/
 /* jshint moz:true */
 
-const { GObject } = imports.gi;
+const { GObject, Shell, Meta  } = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Base = Me.imports.base;
@@ -164,6 +164,24 @@ var SDCInstance = class SDCInstance {
             this._volumeMenuInstance = new VolumeMenuInstance(this._volumeMenu, this._settings);
         }
 
+        // create keybindings
+        const keybindings = [
+            { name: "cycle-output-forward", fn: () => this.cycleDevice(this._outputInstance, 1) },
+            { name: "cycle-output-backward", fn: () => this.cycleDevice(this._outputInstance, -1) },
+            { name: "cycle-input-forward", fn: () => this.cycleDevice(this._inputInstance, 1) },
+            { name: "cycle-input-backward", fn: () => this.cycleDevice(this._inputInstance, -1) }
+        ];
+
+        for (const { name, fn } of keybindings) {
+            Main.wm.addKeybinding(
+                name,
+                this._settings,
+                Meta.KeyBindingFlags.NONE,
+                Shell.ActionMode.NORMAL,
+                fn
+            );
+        }
+
         this._addMenuItem(this._volumeMenu, this._volumeMenu._output.item, this._outputInstance.menuItem);
         this._addMenuItem(this._volumeMenu, this._volumeMenu._input.item, this._inputInstance.menuItem);
         this._expandVolMenu();
@@ -178,6 +196,30 @@ var SDCInstance = class SDCInstance {
             "notify::visible", () => { this._updateMenuVisibility(this._outputInstance, false) });
         this._signalManager.addSignal(getActor(this._volumeMenu._input.item),
             "notify::visible", () => { this._updateMenuVisibility(this._inputInstance, false) });
+    }
+
+    /**
+     * cycle direction = 1 for forward, -1 for backward
+    */ 
+    cycleDevice(InputOutputInstance, direction) {
+        try {
+            let devices = InputOutputInstance._getAvailableDevices();
+            if (devices.length <= 1) {
+                return;
+            }
+
+            let currentActiveDeviceIndex = devices.findIndex(elem => elem.activeDevice === true);
+            if (currentActiveDeviceIndex < 0) {
+                return;
+            }
+
+            let nextDeviceIndex = (((currentActiveDeviceIndex + direction) % devices.length ) + devices.length ) % devices.length;
+            InputOutputInstance._changeDeviceBase(devices[nextDeviceIndex].id, InputOutputInstance._getMixerControl());
+
+            Main.notify('Sound Device Chooser', 'Switched to ' + devices[nextDeviceIndex].title);
+        } catch (e) {
+            console.error(e);
+        }
     }
 
     _addMenuItem(_volumeMenu, checkItem, menuItem) {
@@ -262,6 +304,10 @@ var SDCInstance = class SDCInstance {
     }
 
     disable() {
+        Main.wm.removeKeybinding("cycle-output-forward");
+        Main.wm.removeKeybinding("cycle-output-backward");
+        Main.wm.removeKeybinding("cycle-input-forward");
+        Main.wm.removeKeybinding("cycle-input-backward");
         //this._switchSubmenuMenu();
         this._revertVolMenuChanges();
         if (this._outputInstance) {

--- a/sound-output-device-chooser@kgshank.net/schemas/org.gnome.shell.extensions.sound-output-device-chooser.gschema.xml
+++ b/sound-output-device-chooser@kgshank.net/schemas/org.gnome.shell.extensions.sound-output-device-chooser.gschema.xml
@@ -97,5 +97,29 @@
         <summary>Preference to integrate selector with slider</summary>
         <description></description>
     </key>
-  </schema>
+
+    <key name="cycle-output-forward" type="as">
+        <default><![CDATA[['<Super><Alt>Page_Up']]]></default>
+        <summary>The shortcut to cycle forward through output devices</summary>
+        <description></description>
+    </key>
+
+    <key name="cycle-output-backward" type="as">
+        <default><![CDATA[['<Super><Alt>Page_Down']]]></default>
+        <summary>The shortcut to cycle backward through output devices</summary>
+        <description></description>
+    </key>
+
+    <key name="cycle-input-forward" type="as"> 
+        <default><![CDATA[['<Super><Alt>Home']]]></default>
+        <summary>The shortcut to cycle forward through input devices</summary>
+        <description></description>
+    </key>
+
+    <key name="cycle-input-backward" type="as">
+        <default><![CDATA[['<Super><Alt>End']]]></default>
+        <summary>The shortcut to cycle backward through input devices</summary>
+        <description></description>
+    </key>
+</schema>
 </schemalist>


### PR DESCRIPTION
I responded to this #215 and decided I might as well implement it.

`Super + Alt + Page up/down` for output devices 
`Super + Alt + Home/End` for input devices 