### PR TITLE
Fix gnome-shell crash from BT device profile lookups on stale streams

### DIFF
--- a/sound-output-device-chooser@kgshank.net/base.js
+++ b/sound-output-device-chooser@kgshank.net/base.js
@@ -525,6 +525,15 @@ var SoundDeviceChooserBase = class SoundDeviceChooserBase {
         }
         let uidevice = this.lookupDeviceById(control, id);
         if (uidevice) {
+            // Guard: verify device has a valid stream before switching.
+            // change_output/change_input can trigger a fatal
+            // gvc_mixer_card_get_profile abort if the card's profiles are
+            // stale (e.g. BT device just connected, profiles in flux).
+            let stream = control.get_stream_from_device(uidevice);
+            if (!stream) {
+                _d("No stream for device " + id + ", skipping device change");
+                return;
+            }
             this.changeDevice(control, uidevice);
         }
         else {

--- a/sound-output-device-chooser@kgshank.net/base.js
+++ b/sound-output-device-chooser@kgshank.net/base.js
@@ -388,6 +388,14 @@ var SoundDeviceChooserBase = class SoundDeviceChooserBase {
             this._deviceRemoved(control, id);
         }
         else {
+            // Guard: verify device has a valid stream before changing profile.
+            // change_profile_on_selected_device can trigger a fatal
+            // gvc_mixer_card_get_profile abort if the card's profiles are stale.
+            let stream = control.get_stream_from_device(uidevice);
+            if (!stream) {
+                _d("No stream for device " + id + ", skipping profile change");
+                return;
+            }
             _d("i am setting profile, " + profileName + ":" + uidevice.description + ":" + uidevice.port_name);
             if (id != this._activeDeviceId) {
                 _d("Changing active device to " + uidevice.description + ":" + uidevice.port_name);
@@ -543,6 +551,15 @@ var SoundDeviceChooserBase = class SoundDeviceChooserBase {
             this._deviceRemoved(control, device.id);
         }
         else {
+            // Guard: only get profile if device has a valid stream.
+            // Without this, get_active_profile() can trigger a fatal
+            // gvc_mixer_card_get_profile abort when BT devices are in
+            // a transitional state (e.g. just connected, profiles in flux).
+            let stream = control.get_stream_from_device(uidevice);
+            if (!stream) {
+                _d("No stream for device " + device.id + ", skipping profile update");
+                return;
+            }
             let activeProfile = uidevice.get_active_profile();
             _d("Active Profile:" + activeProfile);
             device.setActiveProfile(activeProfile);

--- a/sound-output-device-chooser@kgshank.net/extension.js
+++ b/sound-output-device-chooser@kgshank.net/extension.js
@@ -252,6 +252,7 @@ var SDCInstance = class SDCInstance {
     }
 
     _updateMenuVisibility(menuInstance, visible) {
+        if (!menuInstance || !menuInstance.menuItem) return;
         if (menuInstance instanceof SoundOutputDeviceChooser) {
             this._integrateMenu(this._volumeMenu, getActor(this._volumeMenu._output.item), getActor(menuInstance.menuItem), visible);
         } else {
@@ -260,10 +261,14 @@ var SDCInstance = class SDCInstance {
     }
 
     _switchSubmenuMenu() {
-        _d("Output Device visibility");
-        this._updateMenuVisibility(this._outputInstance, getActor(this._outputInstance.menuItem).visible);
-        _d("Input Device visibility");
-        this._updateMenuVisibility(this._inputInstance, getActor(this._inputInstance.menuItem).visible);
+        if (this._outputInstance && this._outputInstance.menuItem) {
+            _d("Output Device visibility");
+            this._updateMenuVisibility(this._outputInstance, getActor(this._outputInstance.menuItem).visible);
+        }
+        if (this._inputInstance && this._inputInstance.menuItem) {
+            _d("Input Device visibility");
+            this._updateMenuVisibility(this._inputInstance, getActor(this._inputInstance.menuItem).visible);
+        }
     }
 
     _integrateMenu(_volumeMenu, sliderItem, selectorItem, visible) {


### PR DESCRIPTION
## Summary

Fixes three crash paths that cause gnome-shell to abort on Wayland (resulting in session logout) when Bluetooth audio devices are connecting or switching profiles.

**Commit 1: Null guards in extension.js**
- Adds null guards in `_updateMenuVisibility` and `_switchSubmenuMenu` to prevent `TypeError: menuInstance is null` when Bluetooth audio devices switch profiles (e.g., A2DP ↔ HSP/HFP)

**Commit 2: Stream guards for profile lookups in base.js**
- Adds stream validity checks in `_setDeviceActiveProfile()` and `_profileChangeCallback()` before calling GVC profile methods (`get_active_profile()`, `change_profile_on_selected_device()`)
- Without this, these calls can trigger a fatal `g_assert_not_reached()` in `gvc_mixer_card_get_profile` (`gvc-mixer-card.c:166`), which calls `abort()` — uncatchable from JavaScript
- `_deviceAdded()` already had this stream guard; these two paths did not

**Commit 3: Stream guard for device switching in base.js**
- Adds stream validity check in `_changeDeviceBase()` before calling `changeDevice()` (which calls `control.change_output()` / `control.change_input()`)
- `change_output` internally calls `gvc_mixer_card_get_profile` — same fatal abort as commit 2, but triggered when *clicking* a BT device entry rather than just opening the dropdown

## Reproduction

1. Connect a Bluetooth audio device
2. Device connects but doesn't auto-switch to be the active audio output
3. Either: open the sound device chooser dropdown (crash path 2), or click the BT device entry to switch to it (crash path 3)
4. gnome-shell crashes → session logout on Wayland

## Root cause

When Bluetooth devices are in a transitional state (just connected, profiles in flux):

- **Crash path 1 (extension.js)**: Signal handlers (`update-visibility`, `notify::visible`) fire while `_outputInstance`/`_inputInstance` or their `.menuItem` properties are null → `TypeError` → shell crash
- **Crash path 2 (base.js, `_setDeviceActiveProfile`)**: Opening the submenu triggers `_setActiveProfile()` which iterates all devices and calls `uidevice.get_active_profile()`. For BT devices without a valid stream, this internally calls `gvc_mixer_card_get_profile()` with a profile that doesn't exist on the card → `g_error()` → `abort()` → shell crash
- **Crash path 3 (base.js, `_changeDeviceBase`)**: Clicking a BT device entry calls `changeDevice()` → `control.change_output(uidevice)`, which internally calls `gvc_mixer_card_get_profile()` on a card whose profiles are stale → same `abort()` crash

## Fix

- **extension.js**: Early-return when `menuInstance` or `menuInstance.menuItem` is null
- **base.js**: Check `control.get_stream_from_device(uidevice)` before calling profile methods or device switching; skip with debug log if no stream

Possibly related to #137, #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)