### PR TITLE
Fix labels in per-application output selectors

### DIFF
--- a/sound-output-device-chooser@kgshank.net/convenience.js
+++ b/sound-output-device-chooser@kgshank.net/convenience.js
@@ -37,18 +37,28 @@ else {
 let cards;
 
 function getSinks() {
-    let [result, out, err, exit_code] = GLib.spawn_command_line_sync("pactl list sinks");
+    // Try JSON output (PulseAudio >= 16.0) for friendly descriptions.
+    // LC_NUMERIC=C is required: pactl's JSON uses the locale decimal separator
+    // which makes it invalid JSON on non-English systems (e.g. "0,00" instead of "0.00").
+    let env = GLib.get_environ();
+    env = GLib.environ_setenv(env, "LC_NUMERIC", "C", true);
+    let [, out, , exit_code] = GLib.spawn_sync(null,
+        ["pactl", "--format=json", "list", "sinks"],
+        env, GLib.SpawnFlags.SEARCH_PATH, null);
     let input = imports.byteArray.toString(out);
-    const regex = /Sink #(\d+)\n(?:.|\n)*?device\.description = "(.*?)"(?:.|\n)*?/g;
-    let matches;
-    let sinks = [];
-    while (matches = regex.exec(input)) {
-        sinks.push({
-            id: matches[1],
-            name: matches[2]
-        });
+    if (exit_code === 0) {
+        try {
+            return JSON.parse(input).map(sink => ({ id: String(sink.index), name: sink.description }));
+        } catch (e) {
+            // JSON parse failed (pactl < 16 ignores --format and outputs text); fall through
+        }
     }
-    return sinks;
+    let [, out2] = GLib.spawn_command_line_sync("pactl list short sinks");
+    let input2 = imports.byteArray.toString(out2);
+    return input2.trim().split("\n").filter(l => l).map(line => {
+        let parts = line.split("\t");
+        return { id: parts[0], name: parts[1] };
+    });
 }
 
 function getCard(card_index) {

--- a/sound-output-device-chooser@kgshank.net/volumeMixerPopupMenu.js
+++ b/sound-output-device-chooser@kgshank.net/volumeMixerPopupMenu.js
@@ -52,14 +52,27 @@ var VolumeMixerPopupMenuInstance = class VolumeMixerPopupMenuInstance extends Po
 
 
         let sinks = Lib.getSinks();
-        const menuItem = new PopupMenu.PopupSubMenuMenuItem("Default Output", true, {});
+
+        let currentSinkLabel = "Default Output";
+        let [, siOut] = GLib.spawn_command_line_sync("pactl list short sink-inputs");
+        let siLines = imports.byteArray.toString(siOut).trim().split("\n");
+        for (let line of siLines) {
+            let parts = line.split("\t");
+            if (parts[0] === String(sinkInputId)) {
+                let currentSink = sinks.find(s => s.id === parts[1]);
+                if (currentSink)
+                    currentSinkLabel = currentSink.name;
+                break;
+            }
+        }
+
+        const menuItem = new PopupMenu.PopupSubMenuMenuItem(currentSinkLabel, true, {});
         menuItem.set_style("min-width: 3em;margin-left: 3em;");
         sinks.forEach(sink => {
             if (sink["name"] !== undefined) {
-                menuItem.menu.addAction(sink["id"] + "-" + sink["name"], () => {
-                    var cmd = "pactl " + "move-sink-input" + " " + sinkInputId + " " + sink.id;
-                    GLib.spawn_command_line_sync(cmd);
-                    menuItem.label.text = sink["id"] + "-" + sink["name"];
+                menuItem.menu.addAction(sink["name"], () => {
+                    GLib.spawn_command_line_sync("pactl move-sink-input " + sinkInputId + " " + sink.id);
+                    menuItem.label.text = sink["name"];
                 });
             }
         });


### PR DESCRIPTION
In the per-application output selectors, output selectors appears hard-coded to "Default Output" in my laptop, when I click it, I cannot change it.

It looks like parsing of `pactl` output can be different depending on locales.

This change tries to use JSON when available, and fixes parsing in the cases where the locales may affect the format of the output.

It also tries to use the human-friendly labels in the selector, showing the one that is currently used when available, instead of "Default Output".